### PR TITLE
Update __init__.py

### DIFF
--- a/node_modules/arepl-backend/python/astunparse/__init__.py
+++ b/node_modules/arepl-backend/python/astunparse/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import
-from six.moves import cStringIO
+from six import StringIO
 from .unparser import Unparser
 from .printer import Printer
 
@@ -9,12 +9,12 @@ __version__ = '1.6.3'
 
 
 def unparse(tree):
-    v = cStringIO()
+    v = StringIO()
     Unparser(tree, file=v)
     return v.getvalue()
 
 
 def dump(tree):
-    v = cStringIO()
+    v = StringIO()
     Printer(file=v).visit(tree)
     return v.getvalue()


### PR DESCRIPTION
Fixed "ModuleNotFoundError: No module named 'six.moves'" when using it as an extension in VSCode.